### PR TITLE
makeflow local resources

### DIFF
--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -308,7 +308,7 @@ struct jx * dag_node_env_create( struct dag *d, struct dag_node *n )
 
 /* Return resources according to request. */
 
-const struct rmsummary *dag_node_dynamic_label(struct dag_node *n) {
+const struct rmsummary *dag_node_dynamic_label(const struct dag_node *n) {
 	return category_dynamic_task_max_resources(n->category, NULL, n->resource_request);
 }
 

--- a/makeflow/src/dag_node.c
+++ b/makeflow/src/dag_node.c
@@ -42,7 +42,15 @@ struct dag_node *dag_node_create(struct dag *d, int linenum)
 
 	n->ancestor_depth = -1;
 
+	// resources explicitely requested for only this node in the dag file.
+	// PROBABLY not what you want. Most likely you want dag_node_dynamic_label(n)
 	n->resources_requested = rmsummary_create(-1);
+
+	// the value of dag_node_dynamic_label(n) when this node was submitted.
+	n->resources_allocated  = rmsummary_create(-1);
+
+	// resources used by the node, as measured by the resource_monitor (if
+	// using monitoring).
 	n->resources_measured  = NULL;
 
 	n->resource_request = CATEGORY_ALLOCATION_FIRST;

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -102,7 +102,7 @@ void dag_node_state_change(struct dag *d, struct dag_node *n, int newstate);
 
 struct jx * dag_node_env_create( struct dag *d, struct dag_node *n );
 
-const struct rmsummary *dag_node_dynamic_label(struct dag_node *n);
+const struct rmsummary *dag_node_dynamic_label(const struct dag_node *n);
 
 void dag_node_set_umbrella_spec(struct dag_node *n, const char *umbrella_spec);
 

--- a/makeflow/src/dag_node.h
+++ b/makeflow/src/dag_node.h
@@ -58,7 +58,11 @@ struct dag_node {
 	struct hash_table *variables;       /* This node settings for variables with @ syntax */
 
 	category_allocation_t resource_request;  /* type of allocation for the node (user, unlabeled, max, etc.) */
-	struct rmsummary *resources_requested;   /* resources required by this rule */
+    struct rmsummary *resources_requested;   /* resources required explicitely by this rule alone, not taking
+                                                into account its category. Use dag_node_dynamic_label(n) for the
+                                                resources this node requests, taking into account categories,
+                                                dynamic resources, etc.  */
+    struct rmsummary *resources_allocated;   /* resources allocated to this node when submitted */
 	struct rmsummary *resources_measured;    /* resources measured on completion. */
 
 	/* Variables used in dag_width, dag_width_uniform_task, and dag_depth

--- a/makeflow/src/makeflow.c
+++ b/makeflow/src/makeflow.c
@@ -117,7 +117,7 @@ static batch_queue_type_t batch_queue_type = BATCH_QUEUE_TYPE_LOCAL;
 static struct batch_queue *local_queue = 0;
 static struct batch_queue *remote_queue = 0;
 
-static struct makeflow_local_resources *local_resources = 0;
+static struct rmsummary *local_resources = 0;
 
 static int local_jobs_max = 1;
 static int remote_jobs_max = MAX_REMOTE_JOBS_DEFAULT;

--- a/makeflow/src/makeflow_local_resources.c
+++ b/makeflow/src/makeflow_local_resources.c
@@ -7,29 +7,29 @@
 #include "macros.h"
 #include "debug.h"
 
-struct makeflow_local_resources * makeflow_local_resources_create()
+struct rmsummary * makeflow_local_resources_create()
 {
-	struct makeflow_local_resources *r = malloc(sizeof(*r));
+	struct rmsummary *r = malloc(sizeof(*r));
 	memset(r,0,sizeof(*r));
 	return r;
 }
 
-void makeflow_local_resources_delete( struct makeflow_local_resources *r )
+void makeflow_local_resources_delete( struct rmsummary *r )
 {
 	free(r);
 }
 
-void makeflow_local_resources_print( struct makeflow_local_resources *r )
+void makeflow_local_resources_print( struct rmsummary *r )
 {
-	printf("local resources: %d cores, %d MB memory, %d MB disk\n",r->cores,r->memory,r->disk);
+	printf("local resources: %" PRId64 " cores, %" PRId64 " MB memory, %" PRId64 " MB disk\n",r->cores,r->memory,r->disk);
 }
 
-void makeflow_local_resources_debug( struct makeflow_local_resources *r )
+void makeflow_local_resources_debug( struct rmsummary *r )
 {
-	debug(D_MAKEFLOW,"local resources: %d cores, %d MB memory, %d MB disk\n",r->cores,r->memory,r->disk);
+	debug(D_MAKEFLOW,"local resources: %" PRId64 " cores, %" PRId64 " MB memory, %" PRId64 " MB disk\n",r->cores,r->memory,r->disk);
 }
 
-void makeflow_local_resources_measure( struct makeflow_local_resources *r )
+void makeflow_local_resources_measure( struct rmsummary *r )
 {
 	UINT64_T avail, total;
 
@@ -42,13 +42,13 @@ void makeflow_local_resources_measure( struct makeflow_local_resources *r )
 	r->disk = avail / MEGA;
 }
 
-int  makeflow_local_resources_available( struct makeflow_local_resources *r, struct dag_node *n )
+int  makeflow_local_resources_available( struct rmsummary *r, struct dag_node *n )
 {
 	struct rmsummary *s = n->resources_requested;
 	return s->cores<=r->cores && s->memory<=r->memory && s->disk<=r->disk;
 }
 
-void makeflow_local_resources_subtract( struct makeflow_local_resources *r, struct dag_node *n )
+void makeflow_local_resources_subtract( struct rmsummary *r, struct dag_node *n )
 {
 	struct rmsummary *s = n->resources_requested;
 	if(s->cores>=0)  r->cores -= s->cores;
@@ -57,7 +57,7 @@ void makeflow_local_resources_subtract( struct makeflow_local_resources *r, stru
 	makeflow_local_resources_debug(r);
 }
 
-void makeflow_local_resources_add( struct makeflow_local_resources *r, struct dag_node *n )
+void makeflow_local_resources_add( struct rmsummary *r, struct dag_node *n )
 {
 	struct rmsummary *s = n->resources_requested;
 	if(s->cores>=0)  r->cores += s->cores;

--- a/makeflow/src/makeflow_local_resources.c
+++ b/makeflow/src/makeflow_local_resources.c
@@ -7,18 +7,6 @@
 #include "macros.h"
 #include "debug.h"
 
-struct rmsummary * makeflow_local_resources_create()
-{
-	struct rmsummary *r = malloc(sizeof(*r));
-	memset(r,0,sizeof(*r));
-	return r;
-}
-
-void makeflow_local_resources_delete( struct rmsummary *r )
-{
-	free(r);
-}
-
 void makeflow_local_resources_print( struct rmsummary *r )
 {
 	printf("local resources: %" PRId64 " cores, %" PRId64 " MB memory, %" PRId64 " MB disk\n",r->cores,r->memory,r->disk);
@@ -42,28 +30,28 @@ void makeflow_local_resources_measure( struct rmsummary *r )
 	r->disk = avail / MEGA;
 }
 
-int  makeflow_local_resources_available( struct rmsummary *r, struct dag_node *n )
+int  makeflow_local_resources_available(struct rmsummary *local, const struct rmsummary *resources_asked)
 {
-	struct rmsummary *s = n->resources_requested;
-	return s->cores<=r->cores && s->memory<=r->memory && s->disk<=r->disk;
+	const struct rmsummary *s = resources_asked;
+	return s->cores<=local->cores && s->memory<=local->memory && s->disk<=local->disk;
 }
 
-void makeflow_local_resources_subtract( struct rmsummary *r, struct dag_node *n )
+void makeflow_local_resources_subtract( struct rmsummary *local, struct dag_node *n )
 {
-	struct rmsummary *s = n->resources_requested;
-	if(s->cores>=0)  r->cores -= s->cores;
-	if(s->memory>=0) r->memory -= s->memory;		
-	if(s->disk>=0)   r->disk -= s->disk;
-	makeflow_local_resources_debug(r);
+	const struct rmsummary *s = n->resources_allocated;
+	if(s->cores>=0)  local->cores -= s->cores;
+	if(s->memory>=0) local->memory -= s->memory;		
+	if(s->disk>=0)   local->disk -= s->disk;
+	makeflow_local_resources_debug(local);
 }
 
-void makeflow_local_resources_add( struct rmsummary *r, struct dag_node *n )
+void makeflow_local_resources_add( struct rmsummary *local, struct dag_node *n )
 {
-	struct rmsummary *s = n->resources_requested;
-	if(s->cores>=0)  r->cores += s->cores;
-	if(s->memory>=0) r->memory += s->memory;		
-	if(s->disk>=0)   r->disk += s->disk;
-	makeflow_local_resources_debug(r);
+	const struct rmsummary *s = n->resources_allocated;
+	if(s->cores>=0)  local->cores += s->cores;
+	if(s->memory>=0) local->memory += s->memory;		
+	if(s->disk>=0)   local->disk += s->disk;
+	makeflow_local_resources_debug(local);
 }
 
 

--- a/makeflow/src/makeflow_local_resources.h
+++ b/makeflow/src/makeflow_local_resources.h
@@ -2,22 +2,17 @@
 #define MAKEFLOW_LOCAL_RESOURCES_H
 
 #include "dag_node.h"
+#include "rmsummary.h"
 
-struct makeflow_local_resources {
-	int cores;
-	int memory;
-	int disk;
-};
+struct rmsummary * makeflow_local_resources_create();
+void makeflow_local_resources_delete( struct rmsummary *r );
 
-struct makeflow_local_resources * makeflow_local_resources_create();
-void makeflow_local_resources_delete( struct makeflow_local_resources *r );
+void makeflow_local_resources_print( struct rmsummary *r );
 
-void makeflow_local_resources_print( struct makeflow_local_resources *r );
-
-void makeflow_local_resources_measure( struct makeflow_local_resources *r );
-int  makeflow_local_resources_available( struct makeflow_local_resources *r, struct dag_node *n );
-void makeflow_local_resources_subtract( struct makeflow_local_resources *r, struct dag_node *n );
-void makeflow_local_resources_add( struct makeflow_local_resources *r, struct dag_node *n );
+void makeflow_local_resources_measure( struct rmsummary *r );
+int  makeflow_local_resources_available( struct rmsummary *r, struct dag_node *n );
+void makeflow_local_resources_subtract( struct rmsummary *r, struct dag_node *n );
+void makeflow_local_resources_add( struct rmsummary *r, struct dag_node *n );
 
 
 #endif

--- a/makeflow/src/makeflow_local_resources.h
+++ b/makeflow/src/makeflow_local_resources.h
@@ -4,13 +4,10 @@
 #include "dag_node.h"
 #include "rmsummary.h"
 
-struct rmsummary * makeflow_local_resources_create();
-void makeflow_local_resources_delete( struct rmsummary *r );
-
 void makeflow_local_resources_print( struct rmsummary *r );
 
 void makeflow_local_resources_measure( struct rmsummary *r );
-int  makeflow_local_resources_available( struct rmsummary *r, struct dag_node *n );
+int  makeflow_local_resources_available( struct rmsummary *r, const struct rmsummary *asked);
 void makeflow_local_resources_subtract( struct rmsummary *r, struct dag_node *n );
 void makeflow_local_resources_add( struct rmsummary *r, struct dag_node *n );
 


### PR DESCRIPTION
Use dag_node_dynamic_label(n) instead of n->resources_requested.
Changed  struct makeflow_local_resources  to struct rmsummary.

It works now, but for one thing. Your example does not hang, but the workflow fails, as no job can be run at the end of a cycle. We either need to wait forever, or  print a debug message.